### PR TITLE
Add COMPLETE pragma for Vec: Nil, (:>)

### DIFF
--- a/changelog/2024-05-07T22_51_59+10_00_add_vec_complete_pragma
+++ b/changelog/2024-05-07T22_51_59+10_00_add_vec_complete_pragma
@@ -1,0 +1,1 @@
+ADDED: The Vec type now has a [COMPLETE pragma](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/pragmas.html#complete-pragma) to avoid incomplete pattern matches when using the `(:>)` pattern.

--- a/clash-prelude/src/Clash/Sized/Vector.hs
+++ b/clash-prelude/src/Clash/Sized/Vector.hs
@@ -2,6 +2,7 @@
 Copyright  :  (C) 2013-2016, University of Twente,
                   2017     , Myrtle Software Ltd
                   2022-2023, QBayLogic B.V.
+                  2024,      Alex Mason
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 -}

--- a/clash-prelude/src/Clash/Sized/Vector.hs
+++ b/clash-prelude/src/Clash/Sized/Vector.hs
@@ -180,6 +180,8 @@ data Vec :: Nat -> Type -> Type where
   Nil  :: Vec 0 a
   Cons :: a -> Vec n a -> Vec (n + 1) a
 
+{-# COMPLETE Nil, (:>) #-}
+
 -- | In many cases, this Generic instance only allows generic
 -- functions/instances over vectors of at least size 1, due to the
 -- /n-1/ in the /Rep (Vec n a)/ definition.


### PR DESCRIPTION
I was banging my head against some type errors for hours until I decided to use the `Cons` constructor instead of the `:>` pattern - hopefully this will save someone else the same pain.

[comment]: # (Add a line of the form "Fixes: #xxxx" for each related issue closed by this pull request, where #xxxx is an issue number.)

## Still TODO:

  - [x] Write a changelog entry (see changelog/README.md)
  - [x] Check copyright notices are up to date in edited files
